### PR TITLE
Return true to patch chunk loading

### DIFF
--- a/src/main/java/com/feed_the_beast/mods/ftbchunks/FTBChunksConfig.java
+++ b/src/main/java/com/feed_the_beast/mods/ftbchunks/FTBChunksConfig.java
@@ -137,7 +137,7 @@ public class FTBChunksConfig
 	{
 		if (patchChunkLoading)
 		{
-			return false;
+			return true;
 		}
 
 		return false;


### PR DESCRIPTION
Finally got my dev environment setup and tested to see if this fix was as easy as I was hoping. Force loaded chunks now tick correctly when the player isn't near, even in another dimension.