### PR TITLE
Fixed fake players in claimed chunks.

### DIFF
--- a/src/main/java/com/feed_the_beast/mods/ftbchunks/impl/ClaimedChunkPlayerDataImpl.java
+++ b/src/main/java/com/feed_the_beast/mods/ftbchunks/impl/ClaimedChunkPlayerDataImpl.java
@@ -374,6 +374,10 @@ public class ClaimedChunkPlayerDataImpl implements ClaimedChunkPlayerData
 		{
 			return true;
 		}
+		else if (isInAllyList(p.getUuid()) && FTBChunksAPIImpl.manager.knownFakePlayers.containsKey(p.getUuid()))
+		{
+			return true;
+		}
 
 		return getName().equals(p.getName());
 	}

--- a/src/main/java/com/feed_the_beast/mods/ftbchunks/net/SendPlayerListPacket.java
+++ b/src/main/java/com/feed_the_beast/mods/ftbchunks/net/SendPlayerListPacket.java
@@ -108,6 +108,11 @@ public class SendPlayerListPacket
 				continue;
 			}
 
+			if (FTBChunksAPIImpl.manager.knownFakePlayers.containsKey(p.getUuid()))
+			{
+				continue;
+			}
+
 			int flags = 0;
 
 			if (self.allies.contains(p.getUuid()))


### PR DESCRIPTION
Fixes issues introduced in f2b0b9d
- Fixed fake players showing up twice in the ally screen.
- Fixed fake players being unable to work in claimed chunks even when allied Fixes #58.