### PR TITLE
Make death waypoints a client configuration option

### DIFF
--- a/src/main/java/com/feed_the_beast/mods/ftbchunks/client/FTBChunksClient.java
+++ b/src/main/java/com/feed_the_beast/mods/ftbchunks/client/FTBChunksClient.java
@@ -261,6 +261,7 @@ public class FTBChunksClient extends FTBChunksCommon
 	@Override
 	public void playerDeath(PlayerDeathPacket packet)
 	{
+		/*
 		MapDimension dimension = MapManager.inst.getDimension(packet.dimension);
 		Waypoint w = new Waypoint(dimension);
 		w.name = "Death #" + packet.number;
@@ -269,6 +270,7 @@ public class FTBChunksClient extends FTBChunksCommon
 		w.type = WaypointType.DEATH;
 		dimension.getWaypoints().add(w);
 		dimension.saveData = true;
+		*/
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/feed_the_beast/mods/ftbchunks/client/FTBChunksClient.java
+++ b/src/main/java/com/feed_the_beast/mods/ftbchunks/client/FTBChunksClient.java
@@ -261,16 +261,16 @@ public class FTBChunksClient extends FTBChunksCommon
 	@Override
 	public void playerDeath(PlayerDeathPacket packet)
 	{
-		/*
-		MapDimension dimension = MapManager.inst.getDimension(packet.dimension);
-		Waypoint w = new Waypoint(dimension);
-		w.name = "Death #" + packet.number;
-		w.x = packet.x;
-		w.z = packet.z;
-		w.type = WaypointType.DEATH;
-		dimension.getWaypoints().add(w);
-		dimension.saveData = true;
-		*/
+		if (FTBChunksClientConfig.deathWaypoints) {
+			MapDimension dimension = MapManager.inst.getDimension(packet.dimension);
+			Waypoint w = new Waypoint(dimension);
+			w.name = "Death #" + packet.number;
+			w.x = packet.x;
+			w.z = packet.z;
+			w.type = WaypointType.DEATH;
+			dimension.getWaypoints().add(w);
+			dimension.saveData = true;
+		}
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/feed_the_beast/mods/ftbchunks/client/FTBChunksClientConfig.java
+++ b/src/main/java/com/feed_the_beast/mods/ftbchunks/client/FTBChunksClientConfig.java
@@ -25,6 +25,7 @@ public class FTBChunksClientConfig
 	public static boolean claimedChunksOnMap;
 	public static boolean ownClaimedChunksOnMap;
 	public static boolean inWorldWaypoints;
+	public static boolean deathWaypoints;
 	public static MapMode mapMode;
 	public static int waterHeightFactor;
 
@@ -76,6 +77,7 @@ public class FTBChunksClientConfig
 			claimedChunksOnMap = c.claimedChunksOnMap.get();
 			ownClaimedChunksOnMap = c.ownClaimedChunksOnMap.get();
 			inWorldWaypoints = c.inWorldWaypoints.get();
+			deathWaypoints = c.deathWaypoints.get();
 			mapMode = c.mapMode.get();
 			waterHeightFactor = c.waterHeightFactor.get();
 
@@ -113,6 +115,7 @@ public class FTBChunksClientConfig
 		public final ForgeConfigSpec.BooleanValue claimedChunksOnMap;
 		public final ForgeConfigSpec.BooleanValue ownClaimedChunksOnMap;
 		public final ForgeConfigSpec.BooleanValue inWorldWaypoints;
+		public final ForgeConfigSpec.BooleanValue deathWaypoints;
 		public final ForgeConfigSpec.EnumValue<MapMode> mapMode;
 		public final ForgeConfigSpec.IntValue waterHeightFactor;
 
@@ -174,6 +177,11 @@ public class FTBChunksClientConfig
 					.comment("Show waypoints in world")
 					.translation("ftbchunks.in_world_waypoints")
 					.define("in_world_waypoints", true);
+
+			deathWaypoints = builder
+					.comment("Enables creation of death waypoints")
+					.translation("ftbchunks.death_waypoints")
+					.define("death_waypoints", true);
 
 			mapMode = builder
 					.comment("Different ways to render map")
@@ -304,6 +312,11 @@ public class FTBChunksClientConfig
 		group.addBool("in_world_waypoints", inWorldWaypoints, v -> {
 			client.getLeft().inWorldWaypoints.set(v);
 			inWorldWaypoints = v;
+		}, true);
+
+		group.addBool("death_waypoints", deathWaypoints, v -> {
+			client.getLeft().deathWaypoints.set(v);
+			deathWaypoints = v;
 		}, true);
 
 		group.addEnum("map_mode", mapMode, v -> {

--- a/src/main/resources/assets/ftbchunks/lang/en_us.json
+++ b/src/main/resources/assets/ftbchunks/lang/en_us.json
@@ -9,6 +9,7 @@
 	"ftbchunks.claimed_chunks_on_map": "Show claimed chunks on map",
 	"ftbchunks.own_claimed_chunks_on_map": "Show your own claimed chunks on map",
 	"ftbchunks.in_world_waypoints": "Show waypoints in world",
+	"ftbchunks.death_waypoints": "Create death waypoints on death",
 	"ftbchunks.map_mode": "Map mode",
 	"ftbchunks.water_height_factor": "Water weight factor",
 	"ftbchunks.minimap": "Minimap",


### PR DESCRIPTION
I found myself wanting to disable death waypoints, and I imagine others would like this too. It's always nice to have more configuration options. No breaking changes as it defaults to enabled.