### PR TITLE
Allow spectators to bypass claim protection

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
@@ -165,13 +165,13 @@ public class ClaimedChunkManager {
 				return override.getProtect();
 			}
 
-			return isFake || !getBypassProtection(player.getUUID());
+			return !player.isSpectator() && (isFake || !getBypassProtection(player.getUUID()));
 		} else if (FTBChunksWorldConfig.noWilderness(player)) {
 			ProtectionOverride override = protection.override(player, pos, hand, null);
 
 			if (override.isOverride()) {
 				return override.getProtect();
-			} else if (!isFake && getBypassProtection(player.getUUID())) {
+			} else if (!isFake && (getBypassProtection(player.getUUID()) || player.isSpectator())) {
 				return false;
 			}
 


### PR DESCRIPTION
Spectators should be allowed to open chests in claimed chunks without being an admin