### PR TITLE
[Feature Request] Could you add "Lootr" chests to be opened by any player ( Maybe add in config -> allowed interact blocks )

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbchunks/client/RegionMapButton.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/client/RegionMapButton.java
@@ -7,6 +7,8 @@ import dev.ftb.mods.ftblibrary.icon.Color4I;
 import dev.ftb.mods.ftblibrary.ui.GuiHelper;
 import dev.ftb.mods.ftblibrary.ui.Theme;
 import dev.ftb.mods.ftblibrary.ui.Widget;
+import net.minecraft.client.Minecraft;
+import org.lwjgl.opengl.GL11;
 
 /**
  * @author LatvianModder
@@ -25,6 +27,9 @@ public class RegionMapButton extends Widget {
 
 		if (region.mapImageLoaded) {
 			RenderSystem.bindTexture(id);
+			int filter = w * Minecraft.getInstance().getWindow().getGuiScale() < 512D ? GL11.GL_LINEAR : GL11.GL_NEAREST;
+			RenderSystem.texParameter(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, filter);
+			RenderSystem.texParameter(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, filter);
 			GuiHelper.drawTexturedRect(matrixStack, x, y, w, h, Color4I.WHITE, 0F, 0F, 1F, 1F);
 		}
 	}

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/HeightUtils.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/HeightUtils.java
@@ -25,15 +25,17 @@ public class HeightUtils {
 		return state.isAir() || FTBChunks.PROXY.skipBlock(state);
 	}
 
-	public static BlockPos.MutableBlockPos getHeight(Level level, @Nullable ChunkAccess chunkAccess, BlockPos.MutableBlockPos pos, int[] currentWaterY) {
+	public static int getHeight(Level level, @Nullable ChunkAccess chunkAccess, BlockPos.MutableBlockPos pos) {
 		if (chunkAccess == null) {
-			return pos;
+			return UNKNOWN;
 		}
 
 		int bottomY = 0;
 		int topY = pos.getY();
 		boolean hasCeiling = level.dimensionType().hasCeiling();
+		int currentWaterY = UNKNOWN;
 
+		outer:
 		for (int by = topY; by >= bottomY; by--) {
 			pos.setY(by);
 			BlockState state = chunkAccess.getBlockState(pos);
@@ -43,25 +45,24 @@ public class HeightUtils {
 					pos.setY(by);
 					state = chunkAccess.getBlockState(pos);
 
-					if (state.isAir()) {
-						break;
+					if (skipBlock(state)) {
+						continue outer;
 					}
 				}
 			}
 
 			boolean water = isWater(state);
 
-			if (water && currentWaterY[0] == UNKNOWN) {
-				currentWaterY[0] = by;
+			if (water && currentWaterY == UNKNOWN) {
+				currentWaterY = by;
 			}
 
 			if (!water && !skipBlock(state)) {
-				pos.setY(by);
-				return pos;
+				return currentWaterY;
 			}
 		}
 
 		pos.setY(UNKNOWN);
-		return pos;
+		return UNKNOWN;
 	}
 }

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/net/TeleportFromMapPacket.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/net/TeleportFromMapPacket.java
@@ -74,20 +74,19 @@ public class TeleportFromMapPacket extends BaseC2SMessage {
 					return;
 				}
 
-				BlockPos.MutableBlockPos blockPos = new BlockPos.MutableBlockPos(x, topY, z);
-				int[] water = new int[]{HeightUtils.UNKNOWN};
-				y1 = HeightUtils.getHeight(level, chunkAccess, blockPos, water).getY();
+				BlockPos.MutableBlockPos blockPos = new BlockPos.MutableBlockPos(x, topY + 2, z);
+				int water = HeightUtils.getHeight(level, chunkAccess, blockPos);
 
-				if (y1 == HeightUtils.UNKNOWN) {
-					y1 = 70;
+				if (blockPos.getY() == HeightUtils.UNKNOWN) {
+					blockPos.setY(70);
+				} else if (water != HeightUtils.UNKNOWN) {
+					blockPos.setY(Math.max(blockPos.getY(), water));
 				}
 
-				if (water[0] != HeightUtils.UNKNOWN) {
-					y1 = Math.max(y1, water[0]);
-				}
+				y1 = blockPos.getY() + 1;
 			}
 
-			p.teleportTo(level, x + 0.5D, y1 + 2.1D, z + 0.5D, p.yRot, p.xRot);
+			p.teleportTo(level, x + 0.5D, y1 + 0.1D, z + 0.5D, p.yRot, p.xRot);
 		}
 	}
 }


### PR DESCRIPTION
Hey there, i tried asking for support on your discord. 

On our server we wanna open the Loot Chests that the mod [Lootr](https://www.curseforge.com/minecraft/mc-mods/lootr-fabric) provides on any claimed chunk.

Is there a way i can add this at the moment? 

If not could you add a line in config to add the item_id or so to interact with them 

Now you can open crafting tables and even anvils which brake after some use. So it should be possible

I think this config feature would bring a lot of mod and server support for players 

Played Version: 1.18.2 Fabric

PS: Idk how to open a Pull Request , its my first time, pls be kind <3