### PR TITLE
[1.18] Fix block duplication due to separate Fabric BlockPlace and BlockRightClick events

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunks.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunks.java
@@ -139,7 +139,7 @@ public class FTBChunks {
 		ExplosionEvent.DETONATE.register(this::explosionDetonate);
 		EntityEvent.LIVING_DEATH.register(this::playerDeath); // LOWEST
 		CommandRegistrationEvent.EVENT.register(FTBChunksCommands::registerCommands);
-		TeamEvent.COLLECT_PROPERTIES.register(this::teamConfig);
+		TeamEvent.COLLECT_PROPERTIES.register(FTBChunksExpected::getTeamConfigsForPlatform);
 		TeamEvent.PLAYER_JOINED_PARTY.register(this::playerJoinedParty);
 		TeamEvent.OWNERSHIP_TRANSFERRED.register(this::teamOwnershipTransferred);
 
@@ -252,8 +252,11 @@ public class FTBChunks {
 		return EventResult.pass();
 	}
 
+	/*
+	 * Architectury fabric uses UseBlockCallback for both place and interact.
+	 */
 	public EventResult blockRightClick(Player player, InteractionHand hand, BlockPos pos, Direction face) {
-		if (player instanceof ServerPlayer && FTBChunksAPI.getManager().protect(player, hand, pos, Protection.INTERACT_BLOCK)) {
+		if (player instanceof ServerPlayer && FTBChunksAPI.getManager().protect(player, hand, pos, FTBChunksExpected.getBlockInteractProtectionForPlatform())) {
 			return EventResult.interruptFalse();
 		}
 
@@ -269,15 +272,19 @@ public class FTBChunks {
 	}
 
 	public EventResult blockBreak(Level level, BlockPos pos, BlockState blockState, ServerPlayer player, @Nullable IntValue intValue) {
-		if (FTBChunksAPI.getManager().protect(player, InteractionHand.MAIN_HAND, pos, Protection.EDIT_BLOCK)) {
+		if (FTBChunksAPI.getManager().protect(player, InteractionHand.MAIN_HAND, pos, FTBChunksExpected.getBlockBreakProtectionForPlatform())) {
 			return EventResult.interruptFalse();
 		}
 
 		return EventResult.pass();
 	}
 
+	/*
+	 * This is only called on Forge implementations, since architectury fabric does not have an onBlockPlaced event to override;
+	 * architectury fabric uses UseBlockCallback for both place and interact.
+	 */
 	public EventResult blockPlace(Level level, BlockPos pos, BlockState blockState, @Nullable Entity entity) {
-		if (entity instanceof ServerPlayer && FTBChunksAPI.getManager().protect(entity, InteractionHand.MAIN_HAND, pos, Protection.EDIT_BLOCK)) {
+		if (entity instanceof ServerPlayer && FTBChunksAPI.getManager().protect(entity, InteractionHand.MAIN_HAND, pos, FTBChunksExpected.getBlockPlaceProtectionForPlatform())) {
 			return EventResult.interruptFalse();
 		}
 
@@ -397,14 +404,6 @@ public class FTBChunks {
 		}
 
 		return EventResult.pass();
-	}
-
-	private void teamConfig(TeamCollectPropertiesEvent event) {
-		event.add(FTBChunksTeamData.ALLOW_FAKE_PLAYERS);
-		event.add(FTBChunksTeamData.BLOCK_EDIT_MODE);
-		event.add(FTBChunksTeamData.BLOCK_INTERACT_MODE);
-		// event.add(FTBChunksTeamData.MINIMAP_MODE);
-		// event.add(FTBChunksTeamData.LOCATION_MODE);
 	}
 
 	private void playerJoinedParty(PlayerJoinedPartyTeamEvent event) {

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunksExpected.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunksExpected.java
@@ -1,6 +1,8 @@
 package dev.ftb.mods.ftbchunks;
 
 import dev.architectury.injectables.annotations.ExpectPlatform;
+import dev.ftb.mods.ftbchunks.data.Protection;
+import dev.ftb.mods.ftbteams.event.TeamCollectPropertiesEvent;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 
@@ -9,6 +11,26 @@ import java.util.UUID;
 public class FTBChunksExpected {
     @ExpectPlatform
     public static void addChunkToForceLoaded(ServerLevel level, String modId, UUID owner, int chunkX, int chunkY, boolean add) {
+        throw new AssertionError();
+    }
+
+    @ExpectPlatform
+    public static void getTeamConfigsForPlatform(TeamCollectPropertiesEvent event) {
+        throw new AssertionError();
+    }
+
+    @ExpectPlatform
+    public static Protection getBlockPlaceProtectionForPlatform() {
+        throw new AssertionError();
+    }
+
+    @ExpectPlatform
+    public static Protection getBlockInteractProtectionForPlatform() {
+        throw new AssertionError();
+    }
+
+    @ExpectPlatform
+    public static Protection getBlockBreakProtectionForPlatform() {
         throw new AssertionError();
     }
 }

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
@@ -167,9 +167,12 @@ public class ClaimedChunkManager {
 
 			if (override.isOverride()) {
 				return override.getProtect();
+			} else if (!isFake && getBypassProtection(player.getUUID())) {
+				return false;
 			}
 
-			return isFake || !getBypassProtection(player.getUUID());
+			player.displayClientMessage(new TextComponent("You do not have permission to interact with blocks here!"), true);
+			return true;
 		} else if (FTBChunksWorldConfig.noWilderness(player)) {
 			ProtectionOverride override = protection.override(player, pos, hand, null);
 

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/FTBChunksTeamData.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/FTBChunksTeamData.java
@@ -11,6 +11,7 @@ import dev.ftb.mods.ftblibrary.snbt.SNBTCompoundTag;
 import dev.ftb.mods.ftbteams.FTBTeamsAPI;
 import dev.ftb.mods.ftbteams.data.PrivacyMode;
 import dev.ftb.mods.ftbteams.data.Team;
+import dev.ftb.mods.ftbteams.data.TeamRank;
 import dev.ftb.mods.ftbteams.property.BooleanProperty;
 import dev.ftb.mods.ftbteams.property.PrivacyProperty;
 import net.minecraft.Util;
@@ -41,6 +42,7 @@ public class FTBChunksTeamData {
 	public static final BooleanProperty ALLOW_FAKE_PLAYERS = new BooleanProperty(new ResourceLocation(FTBChunks.MOD_ID, "allow_fake_players"), true);
 	public static final PrivacyProperty BLOCK_EDIT_MODE = new PrivacyProperty(new ResourceLocation(FTBChunks.MOD_ID, "block_edit_mode"), PrivacyMode.ALLIES);
 	public static final PrivacyProperty BLOCK_INTERACT_MODE = new PrivacyProperty(new ResourceLocation(FTBChunks.MOD_ID, "block_interact_mode"), PrivacyMode.ALLIES);
+	public static final PrivacyProperty BLOCK_EDIT_AND_INTERACT_MODE = new PrivacyProperty(new ResourceLocation(FTBChunks.MOD_ID, "block_edit_and_interact_mode"), PrivacyMode.ALLIES);
 	public static final PrivacyProperty MINIMAP_MODE = new PrivacyProperty(new ResourceLocation(FTBChunks.MOD_ID, "minimap_mode"), PrivacyMode.ALLIES);
 	public static final PrivacyProperty LOCATION_MODE = new PrivacyProperty(new ResourceLocation(FTBChunks.MOD_ID, "location_mode"), PrivacyMode.ALLIES);
 
@@ -276,6 +278,8 @@ public class FTBChunksTeamData {
 			}
 
 			return isAlly(p.getUUID());
+		} else if (mode == PrivacyMode.PRIVATE) {
+			return team.getRanked(TeamRank.OWNER).containsKey(p.getUUID());
 		}
 
 		return team.isMember(p.getUUID());

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/Protection.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/Protection.java
@@ -4,12 +4,26 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 @FunctionalInterface
 public interface Protection {
+
+	Protection EDIT_AND_INTERACT_BLOCK = (player, pos, hand, chunk) -> {
+		BlockState blockState = player.level.getBlockState(pos);
+
+		if (blockState.is(FTBChunksAPI.INTERACT_WHITELIST_TAG)) {
+			return ProtectionOverride.ALLOW;
+		}
+
+		if (chunk != null && chunk.teamData.canUse(player, FTBChunksTeamData.BLOCK_EDIT_AND_INTERACT_MODE)) {
+			return ProtectionOverride.ALLOW;
+		}
+
+		return ProtectionOverride.CHECK;
+	};
+
 	Protection EDIT_BLOCK = (player, pos, hand, chunk) -> {
 		BlockState blockState = player.level.getBlockState(pos);
 

--- a/fabric/src/main/java/dev/ftb/mods/ftbchunks/fabric/FTBChunksExpectedImpl.java
+++ b/fabric/src/main/java/dev/ftb/mods/ftbchunks/fabric/FTBChunksExpectedImpl.java
@@ -1,5 +1,8 @@
 package dev.ftb.mods.ftbchunks.fabric;
 
+import dev.ftb.mods.ftbchunks.data.FTBChunksTeamData;
+import dev.ftb.mods.ftbchunks.data.Protection;
+import dev.ftb.mods.ftbteams.event.TeamCollectPropertiesEvent;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.TicketType;
 import net.minecraft.world.level.ChunkPos;
@@ -15,5 +18,22 @@ public class FTBChunksExpectedImpl {
         } else {
             level.getChunkSource().removeRegionTicket(TicketType.FORCED, chunkPos, 2, chunkPos);
         }
+    }
+
+    public static void getTeamConfigsForPlatform(TeamCollectPropertiesEvent event) {
+        event.add(FTBChunksTeamData.ALLOW_FAKE_PLAYERS);
+        event.add(FTBChunksTeamData.BLOCK_EDIT_AND_INTERACT_MODE);
+    }
+
+    public static Protection getBlockPlaceProtectionForPlatform() {
+        return Protection.EDIT_AND_INTERACT_BLOCK;
+    }
+
+    public static Protection getBlockInteractProtectionForPlatform() {
+        return Protection.EDIT_AND_INTERACT_BLOCK;
+    }
+
+    public static Protection getBlockBreakProtectionForPlatform() {
+        return Protection.EDIT_AND_INTERACT_BLOCK;
     }
 }

--- a/forge/src/main/java/dev/ftb/mods/ftbchunks/forge/FTBChunksExpectedImpl.java
+++ b/forge/src/main/java/dev/ftb/mods/ftbchunks/forge/FTBChunksExpectedImpl.java
@@ -1,5 +1,8 @@
 package dev.ftb.mods.ftbchunks.forge;
 
+import dev.ftb.mods.ftbchunks.data.FTBChunksTeamData;
+import dev.ftb.mods.ftbchunks.data.Protection;
+import dev.ftb.mods.ftbteams.event.TeamCollectPropertiesEvent;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.common.world.ForgeChunkManager;
 
@@ -8,5 +11,23 @@ import java.util.UUID;
 public class FTBChunksExpectedImpl {
     public static void addChunkToForceLoaded(ServerLevel level, String modId, UUID owner, int chunkX, int chunkY, boolean add) {
         ForgeChunkManager.forceChunk(level, modId, owner, chunkX, chunkY, add, false);
+    }
+
+    public static void getTeamConfigsForPlatform(TeamCollectPropertiesEvent event) {
+        event.add(FTBChunksTeamData.ALLOW_FAKE_PLAYERS);
+        event.add(FTBChunksTeamData.BLOCK_EDIT_MODE);
+        event.add(FTBChunksTeamData.BLOCK_INTERACT_MODE);
+    }
+
+    public static Protection getBlockPlaceProtectionForPlatform() {
+        return Protection.EDIT_BLOCK;
+    }
+
+    public static Protection getBlockInteractProtectionForPlatform() {
+        return Protection.INTERACT_BLOCK;
+    }
+
+    public static Protection getBlockBreakProtectionForPlatform() {
+        return Protection.EDIT_BLOCK;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/FTBTeam/FTB-Mods-Issues/issues/315.

**Key changes:**
- Adds new protection, block_edit_and_interact, that is used on Fabric platforms instead of block_edit and block_interact, since we cannot differentiate block placement and block interact in Fabric Architectury.
- Adds platform-dependent protection selection for events.

Tested in fabric dev environment on with server and two clients.