### PR TITLE
fix: add guard to prevent server crashes when player.level is null

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
@@ -196,6 +196,12 @@ public class ClaimedChunkManager {
 			return FTBChunksWorldConfig.FAKE_PLAYERS.get().getProtect();
 		}
 
+		// Some mod interactions can cause player.level to be null
+		if (!(player.level instanceof Level))
+		{
+			return false;
+		}
+
 		ClaimedChunk chunk = getChunk(new ChunkDimPos(player.level, pos));
 
 		if (chunk != null) {


### PR DESCRIPTION
Within the DireWolf20 1.19.2 modpack, version 1.0.1 and beyond, we discovered what seems to be an interaction between Mekanism's Digital Miner clearing trees and potentially an unidentified mod that forces tree leaves to despawn faster that caused `player.level` in `ClaimedChunkManager.protect` to be null. Since downstream usage of `player.level` did not guard against null values, this bubbled up as an unhandled exception in the Event Bus, and subsequently would crash the server completely.

We had a repeatable world snapshot that would crash after a few minutes, and were able to track it down to the following stack trace:

```
java.lang.NullPointerException: Cannot invoke "net.minecraft.world.level.Level.m_46472_()" because "world" is null
	at TRANSFORMER/ftblibrary@1902.3.11-build.166/dev.ftb.mods.ftblibrary.math.ChunkDimPos.<init>(ChunkDimPos.java:32)
	at TRANSFORMER/ftbchunks@1902.3.14-build.218/dev.ftb.mods.ftbchunks.data.ClaimedChunkManager.protect(ClaimedChunkManager.java:199)
	at TRANSFORMER/ftbchunks@1902.3.14-build.218/dev.ftb.mods.ftbchunks.FTBChunks.blockBreak(FTBChunks.java:280)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(Unknown Source)
	at TRANSFORMER/architectury@6.4.62/dev.architectury.event.EventFactory.invokeMethod(EventFactory.java:53)
	at TRANSFORMER/architectury@6.4.62/dev.architectury.event.EventFactory$2.handleInvocation(EventFactory.java:81)
	at MC-BOOTSTRAP/com.google.common@31.0.1-jre/com.google.common.reflect.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:89)
	at TRANSFORMER/jdk.proxy3/jdk.proxy3.$Proxy133.breakBlock(Unknown Source)
	at TRANSFORMER/accelerateddecay@1.0.0+mc1.19.2/pro.mikey.accelerateddecay.AcceleratedDecay.levelTick(AcceleratedDecay.java:68)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(Unknown Source)
	at TRANSFORMER/architectury@6.4.62/dev.architectury.event.EventFactory.invokeMethod(EventFactory.java:53)
	at TRANSFORMER/architectury@6.4.62/dev.architectury.event.EventFactory$1.handleInvocation(EventFactory.java:62)
	at MC-BOOTSTRAP/com.google.common@31.0.1-jre/com.google.common.reflect.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:89)
	at TRANSFORMER/jdk.proxy3/jdk.proxy3.$Proxy124.tick(Unknown Source)
	at TRANSFORMER/architectury@6.4.62/dev.architectury.event.forge.EventHandlerImplCommon.event(EventHandlerImplCommon.java:79)
	at TRANSFORMER/architectury@6.4.62/dev.architectury.event.forge.__EventHandlerImplCommon_event_LevelTickEvent.invoke(.dynamic)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:73)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.post(EventBus.java:315)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.post(EventBus.java:296)
	at TRANSFORMER/forge@43.2.3/net.minecraftforge.event.ForgeEventFactory.onPostLevelTick(ForgeEventFactory.java:820)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:872)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.dedicated.DedicatedServer.m_5703_(DedicatedServer.java:292)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:806)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:654)
	at TRANSFORMER/minecraft@1.19.2/net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:244)
	at java.base/java.lang.Thread.run(Unknown Source)
```

With the provided guard in place, the server no longer crashes, even in our repeatable scenario.

I'm not sure if this is the _best_ solution, as I don't have enough Minecraft/Forge/FTB-Chunks knowledge to say, but this is at least keeping our server from crashing anymore. I figured I'd share it.