### PR TITLE
Workaround Arch's block break not being sufficient

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunks.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunks.java
@@ -116,7 +116,7 @@ public class FTBChunks {
 		InteractionEvent.INTERACT_ENTITY.register(this::interactEntity);
 		InteractionEvent.FARMLAND_TRAMPLE.register(this::farmlandTrample);
 
-		BlockEvent.BREAK.register(FTBChunks::blockBreak);
+		BlockEvent.BREAK.register(this::blockBreak);
 		BlockEvent.PLACE.register(this::blockPlace);
 
 		PlayerEvent.PLAYER_QUIT.register(this::loggedOut);
@@ -302,7 +302,7 @@ public class FTBChunks {
 		return EventResult.pass();
 	}
 
-	public static EventResult blockBreak(Level level, BlockPos pos, BlockState blockState, ServerPlayer player, @Nullable IntValue intValue) {
+	public EventResult blockBreak(Level level, BlockPos pos, BlockState blockState, ServerPlayer player, @Nullable IntValue intValue) {
 		if (FTBChunksAPI.getManager().protect(player, InteractionHand.MAIN_HAND, pos, FTBChunksExpected.getBlockBreakProtection(), null)) {
 			return EventResult.interruptFalse();
 		}

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunks.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunks.java
@@ -116,7 +116,7 @@ public class FTBChunks {
 		InteractionEvent.INTERACT_ENTITY.register(this::interactEntity);
 		InteractionEvent.FARMLAND_TRAMPLE.register(this::farmlandTrample);
 
-		BlockEvent.BREAK.register(this::blockBreak);
+		BlockEvent.BREAK.register(FTBChunks::blockBreak);
 		BlockEvent.PLACE.register(this::blockPlace);
 
 		PlayerEvent.PLAYER_QUIT.register(this::loggedOut);
@@ -302,7 +302,7 @@ public class FTBChunks {
 		return EventResult.pass();
 	}
 
-	public EventResult blockBreak(Level level, BlockPos pos, BlockState blockState, ServerPlayer player, @Nullable IntValue intValue) {
+	public static EventResult blockBreak(Level level, BlockPos pos, BlockState blockState, ServerPlayer player, @Nullable IntValue intValue) {
 		if (FTBChunksAPI.getManager().protect(player, InteractionHand.MAIN_HAND, pos, FTBChunksExpected.getBlockBreakProtection(), null)) {
 			return EventResult.interruptFalse();
 		}

--- a/fabric/src/main/java/dev/ftb/mods/ftbchunks/fabric/FTBChunksFabric.java
+++ b/fabric/src/main/java/dev/ftb/mods/ftbchunks/fabric/FTBChunksFabric.java
@@ -12,9 +12,10 @@ public class FTBChunksFabric implements ModInitializer {
 	public void onInitialize() {
 		FTBChunks.instance = new FTBChunks();
 
+		// Temporary until Arch makes BlockEvent.BREAK event be fired from Fabric API's PlayerBlockBreakEvents.BEFORE event.
 		PlayerBlockBreakEvents.BEFORE.register((level, player, blockPos, blockState, blockEntity) -> {
 			if (player instanceof ServerPlayer serverPlayer) {
-				return !FTBChunks.blockBreak(level, blockPos, blockState, serverPlayer, null).isFalse();
+				return !FTBChunks.instance.blockBreak(level, blockPos, blockState, serverPlayer, null).isFalse();
 			}
 			 return true;
 		});

--- a/fabric/src/main/java/dev/ftb/mods/ftbchunks/fabric/FTBChunksFabric.java
+++ b/fabric/src/main/java/dev/ftb/mods/ftbchunks/fabric/FTBChunksFabric.java
@@ -4,11 +4,20 @@ import dev.architectury.platform.Platform;
 import dev.ftb.mods.ftbchunks.FTBChunks;
 import dev.ftb.mods.ftbchunks.compat.waystones.WaystonesCompat;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
+import net.minecraft.server.level.ServerPlayer;
 
 public class FTBChunksFabric implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		FTBChunks.instance = new FTBChunks();
+
+		PlayerBlockBreakEvents.BEFORE.register((level, player, blockPos, blockState, blockEntity) -> {
+			if (player instanceof ServerPlayer serverPlayer) {
+				return !FTBChunks.blockBreak(level, blockPos, blockState, serverPlayer, null).isFalse();
+			}
+			 return true;
+		});
 
 		if (Platform.isModLoaded("waystones")) {
 			WaystonesCompat.init();


### PR DESCRIPTION
The BlockEvent.BREAK event from Arch seems to not fire for PlayerBlockBreakEvents.BEFORE which Fabric mods uses for checking if their actions are allowed or not by claims mods.

This PR does a simple solution of registering to the PlayerBlockBreakEvents.BEFORE event on the Fabric side manually. Should be good for compat and work with my Bumblezone mod (I tested in dev with this change and it looks all good)

I did need to change one method to be static if that's ok as it seems like the cleanest change to do to make this work