### PR TITLE
OP controls everything

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunks.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunks.java
@@ -421,6 +421,7 @@ public class FTBChunks {
 		event.add(FTBChunksTeamData.ALLOW_FAKE_PLAYERS);
 		event.add(FTBChunksTeamData.BLOCK_EDIT_MODE);
 		event.add(FTBChunksTeamData.BLOCK_INTERACT_MODE);
+		event.add(FTBChunksTeamData.ALLOW_EXPLOSIONS);
 		// event.add(FTBChunksTeamData.MINIMAP_MODE);
 		// event.add(FTBChunksTeamData.LOCATION_MODE);
 	}

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunksWorldConfig.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunksWorldConfig.java
@@ -1,18 +1,9 @@
 package dev.ftb.mods.ftbchunks;
 
-import dev.ftb.mods.ftbchunks.data.AllyMode;
-import dev.ftb.mods.ftbchunks.data.ClaimedChunk;
-import dev.ftb.mods.ftbchunks.data.FTBChunksAPI;
-import dev.ftb.mods.ftbchunks.data.FTBChunksTeamData;
-import dev.ftb.mods.ftbchunks.data.ProtectionOverride;
+import dev.ftb.mods.ftbchunks.data.*;
 import dev.ftb.mods.ftblibrary.config.NameMap;
 import dev.ftb.mods.ftblibrary.math.ChunkDimPos;
-import dev.ftb.mods.ftblibrary.snbt.config.BooleanValue;
-import dev.ftb.mods.ftblibrary.snbt.config.EnumValue;
-import dev.ftb.mods.ftblibrary.snbt.config.IntValue;
-import dev.ftb.mods.ftblibrary.snbt.config.SNBTConfig;
-import dev.ftb.mods.ftblibrary.snbt.config.StringListValue;
-import me.shedaniel.architectury.hooks.LevelResourceHooks;
+import dev.ftb.mods.ftblibrary.snbt.config.*;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -28,7 +19,7 @@ import java.util.Set;
  * @author LatvianModder
  */
 public interface FTBChunksWorldConfig {
-	LevelResource CONFIG_FILE_PATH = LevelResourceHooks.create("serverconfig/ftbchunks.snbt");
+	LevelResource CONFIG_FILE_PATH = new LevelResource("serverconfig/ftbchunks.snbt");
 	SNBTConfig CONFIG = SNBTConfig.create(FTBChunks.MOD_ID + "-world");
 
 	EnumValue<ProtectionOverride> FAKE_PLAYERS = CONFIG.getEnum("fake_players", NameMap.of(ProtectionOverride.CHECK, ProtectionOverride.values()).create()).comment("Override to disable/enable fake players like miners and auto-clickers globally. Default will check this setting for each team");
@@ -60,12 +51,8 @@ public interface FTBChunksWorldConfig {
 		return MAX_FORCE_LOADED_CHUNKS.get() + playerData.getExtraForceLoadChunks();
 	}
 
-	static boolean getChunkLoadOffline(FTBChunksTeamData playerData, ServerPlayer player) {
-		if (FTBChunks.ranksMod && player != null) {
-			return FTBRanksIntegration.getChunkLoadOffline(player, CHUNK_LOAD_OFFLINE.get());
-		}
-
-		return CHUNK_LOAD_OFFLINE.get();
+	static boolean canPlayerOfflineForceload(ServerPlayer player) {
+		return FTBChunks.ranksMod && player != null && FTBRanksIntegration.getChunkLoadOffline(player, false);
 	}
 
 	static boolean patchChunkLoading(ServerLevel world, ChunkPos pos) {

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/client/RegionMapButton.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/client/RegionMapButton.java
@@ -7,6 +7,8 @@ import dev.ftb.mods.ftblibrary.icon.Color4I;
 import dev.ftb.mods.ftblibrary.ui.GuiHelper;
 import dev.ftb.mods.ftblibrary.ui.Theme;
 import dev.ftb.mods.ftblibrary.ui.Widget;
+import net.minecraft.client.Minecraft;
+import org.lwjgl.opengl.GL11;
 
 /**
  * @author LatvianModder
@@ -25,6 +27,9 @@ public class RegionMapButton extends Widget {
 
 		if (region.mapImageLoaded) {
 			RenderSystem.bindTexture(id);
+			int filter = w * Minecraft.getInstance().getWindow().getGuiScale() < 512D ? GL11.GL_LINEAR : GL11.GL_NEAREST;
+			RenderSystem.texParameter(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, filter);
+			RenderSystem.texParameter(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, filter);
 			GuiHelper.drawTexturedRect(matrixStack, x, y, w, h, Color4I.WHITE, 0F, 0F, 1F, 1F);
 		}
 	}

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunk.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunk.java
@@ -1,5 +1,6 @@
 package dev.ftb.mods.ftbchunks.data;
 
+import dev.ftb.mods.ftbchunks.FTBChunks;
 import dev.ftb.mods.ftbchunks.event.ClaimedChunkEvent;
 import dev.ftb.mods.ftbchunks.net.SendChunkPacket;
 import dev.ftb.mods.ftblibrary.math.ChunkDimPos;
@@ -7,7 +8,6 @@ import net.minecraft.Util;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.ChunkPos;
 
 /**
  * @author LatvianModder
@@ -73,9 +73,9 @@ public class ClaimedChunk implements ClaimResult {
 		ServerLevel world = getTeamData().getManager().getMinecraftServer().getLevel(getPos().dimension);
 
 		if (world != null) {
-			if (world.setChunkForced(getPos().x, getPos().z, load)) {
-				sendUpdateToAll();
-			}
+			boolean changed = world.setChunkForced(getPos().x, getPos().z, load);
+			FTBChunks.LOGGER.debug("set chunk {},{} forced={} change_made={}", getPos().x, getPos().z, load, changed);
+			if (changed) sendUpdateToAll();
 		}
 	}
 

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunk.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunk.java
@@ -7,6 +7,7 @@ import net.minecraft.Util;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ChunkPos;
 
 /**
  * @author LatvianModder
@@ -65,7 +66,7 @@ public class ClaimedChunk implements ClaimResult {
 	}
 
 	public boolean allowExplosions() {
-		return false;
+		return teamData.allowExplosions();
 	}
 
 	public void postSetForceLoaded(boolean load) {

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
@@ -20,6 +20,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.storage.LevelResource;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -123,6 +124,20 @@ public class ClaimedChunkManager {
 	public boolean hasData(ServerPlayer player) {
 		Team team = FTBTeamsAPI.getManager().getPlayerTeam(player.getUUID());
 		return team != null && teamData.containsKey(team.getId());
+	}
+
+	public void deleteTeam(Team toDelete) {
+		FTBChunksTeamData data = teamData.get(toDelete.getId());
+
+		if (data != null && toDelete.getMembers().isEmpty()) {
+			FTBChunks.LOGGER.debug("dropping references to empty team " + toDelete.getId());
+			teamData.remove(toDelete.getId());
+			try {
+				Files.deleteIfExists(data.file);
+			} catch (IOException e) {
+				FTBChunks.LOGGER.error(String.format("can't delete file %s: %s", data.file, e.getMessage()));
+			}
+		}
 	}
 
 	@Nullable

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
@@ -5,6 +5,7 @@ import dev.ftb.mods.ftbchunks.FTBChunksWorldConfig;
 import dev.ftb.mods.ftblibrary.math.ChunkDimPos;
 import dev.ftb.mods.ftblibrary.snbt.SNBT;
 import dev.ftb.mods.ftbteams.FTBTeamsAPI;
+import dev.ftb.mods.ftbteams.data.PlayerTeam;
 import dev.ftb.mods.ftbteams.data.Team;
 import dev.ftb.mods.ftbteams.data.TeamManager;
 import me.shedaniel.architectury.hooks.LevelResourceHooks;
@@ -150,12 +151,16 @@ public class ClaimedChunkManager {
 	}
 
 	public boolean getBypassProtection(UUID player) {
-		return teamManager.getInternalPlayerTeam(player).getExtraData().getBoolean("BypassFTBChunksProtection");
+		PlayerTeam team = teamManager.getInternalPlayerTeam(player);
+		return team != null && team.getExtraData().getBoolean("BypassFTBChunksProtection");
 	}
 
 	public void setBypassProtection(UUID player, boolean bypass) {
-		teamManager.getInternalPlayerTeam(player).getExtraData().putBoolean("BypassFTBChunksProtection", bypass);
-		teamManager.getInternalPlayerTeam(player).save();
+		PlayerTeam team = teamManager.getInternalPlayerTeam(player);
+		if (team != null) {
+			team.getExtraData().putBoolean("BypassFTBChunksProtection", bypass);
+			team.save();
+		}
 	}
 
 	public boolean protect(@Nullable Entity entity, InteractionHand hand, BlockPos pos, Protection protection) {

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunkManager.java
@@ -8,7 +8,6 @@ import dev.ftb.mods.ftbteams.FTBTeamsAPI;
 import dev.ftb.mods.ftbteams.data.PlayerTeam;
 import dev.ftb.mods.ftbteams.data.Team;
 import dev.ftb.mods.ftbteams.data.TeamManager;
-import me.shedaniel.architectury.hooks.LevelResourceHooks;
 import me.shedaniel.architectury.hooks.PlayerHooks;
 import me.shedaniel.architectury.platform.Platform;
 import net.minecraft.core.BlockPos;
@@ -33,7 +32,7 @@ import java.util.UUID;
  * @author LatvianModder
  */
 public class ClaimedChunkManager {
-	public static final LevelResource DATA_DIR = LevelResourceHooks.create("ftbchunks");
+	public static final LevelResource DATA_DIR = new LevelResource("ftbchunks");
 
 	public final TeamManager teamManager;
 
@@ -63,21 +62,6 @@ public class ClaimedChunkManager {
 		}
 	}
 
-	public void init() {
-		long nanos = System.nanoTime();
-
-		int forceLoaded = 0;
-
-		for (ClaimedChunk chunk : claimedChunks.values()) {
-			if (chunk.isForceLoaded() && chunk.getTeamData().getChunkLoadOffline()) {
-				forceLoaded++;
-				chunk.postSetForceLoaded(true);
-			}
-		}
-
-		FTBChunks.LOGGER.info("Server " + teamManager.getId() + ": Loaded " + claimedChunks.size() + " chunks (" + forceLoaded + " force loaded) from " + teamData.size() + " teams in " + ((System.nanoTime() - nanos) / 1000000D) + "ms");
-	}
-
 	private FTBChunksTeamData loadTeamData(Team team) {
 		Path path = dataDirectory.resolve(team.getId() + ".snbt");
 		FTBChunksTeamData data = new FTBChunksTeamData(this, path, team);
@@ -86,13 +70,6 @@ public class ClaimedChunkManager {
 		if (dataFile != null) {
 			data.deserializeNBT(dataFile);
 			teamData.put(team.getId(), data);
-
-			for (ClaimedChunk chunk : data.getClaimedChunks()) {
-				if (chunk.isForceLoaded() && chunk.getTeamData().getChunkLoadOffline()) {
-					chunk.postSetForceLoaded(true);
-				}
-			}
-
 			return data;
 		}
 

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/FTBChunksTeamData.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/FTBChunksTeamData.java
@@ -10,6 +10,7 @@ import dev.ftb.mods.ftblibrary.snbt.SNBTCompoundTag;
 import dev.ftb.mods.ftbteams.FTBTeamsAPI;
 import dev.ftb.mods.ftbteams.data.PrivacyMode;
 import dev.ftb.mods.ftbteams.data.Team;
+import dev.ftb.mods.ftbteams.data.TeamType;
 import dev.ftb.mods.ftbteams.property.BooleanProperty;
 import dev.ftb.mods.ftbteams.property.PrivacyProperty;
 import me.shedaniel.architectury.hooks.PlayerHooks;
@@ -25,10 +26,8 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author LatvianModder
@@ -51,6 +50,8 @@ public class FTBChunksTeamData {
 	public int extraForceLoadChunks;
 	public boolean chunkLoadOffline;
 	public boolean hasMembersOnline;
+	// claims owned by team members before they joined the team - to be returned when player leaves a party
+	public final Map<UUID, Set<ChunkDimPos>> originalClaims;
 
 	public int prevChunkX = Integer.MAX_VALUE, prevChunkZ = Integer.MAX_VALUE;
 	public String lastChunkID = "";
@@ -66,6 +67,7 @@ public class FTBChunksTeamData {
 		extraForceLoadChunks = 0;
 		chunkLoadOffline = true;
 		hasMembersOnline = false;
+		originalClaims = new HashMap<>();
 	}
 
 	@Override
@@ -109,6 +111,26 @@ public class FTBChunksTeamData {
 		return list;
 	}
 
+	public Collection<ClaimedChunk> getOriginalClaims(UUID playerID) {
+		if (!originalClaims.containsKey(playerID)) return Collections.emptyList();
+
+		List<ClaimedChunk> res = new ArrayList<>();
+		for (ChunkDimPos cdp : originalClaims.get(playerID)) {
+			ClaimedChunk cc = manager.getChunk(cdp);
+			// original claim must still be claimed, and by the current team
+			if (cc != null && cc.teamData == this) {
+				res.add(manager.getChunk(cdp));
+			}
+		}
+
+		return res;
+	}
+
+	public void noteOriginalClaims(FTBChunksTeamData originalTeam) {
+		List<ChunkDimPos> claimedChunks = originalTeam.getClaimedChunks().stream().map(cc -> cc.pos).collect(Collectors.toList());
+		originalClaims.computeIfAbsent(originalTeam.getTeamId(), k -> new HashSet<>()).addAll(claimedChunks);
+	}
+	
 	public void updateLimits(ServerPlayer ownerPlayer) {
 		if (maxClaimChunks != -1 && team.getType().isParty() && !ownerPlayer.getUUID().equals(team.getOwner())) {
 			return;
@@ -312,6 +334,24 @@ public class FTBChunksTeamData {
 
 		tag.put("chunks", chunksTag);
 
+		if (team.getType() == TeamType.PARTY && !originalClaims.isEmpty()) {
+			CompoundTag originalClaimsTag = new CompoundTag();
+			originalClaims.forEach((id, posList) -> {
+				CompoundTag playerTag = new CompoundTag();
+				Map<String,ListTag> perDimensionTags = new HashMap<>();
+				posList.forEach(c -> {
+					ListTag l = perDimensionTags.computeIfAbsent(c.dimension.location().toString(), k -> new ListTag());
+					CompoundTag cdpTag = new CompoundTag();
+					cdpTag.putInt("x", c.x);
+					cdpTag.putInt("z", c.z);
+					l.add(cdpTag);
+				});
+				perDimensionTags.forEach(playerTag::put);
+				originalClaimsTag.put(id.toString(), playerTag);
+			});
+			tag.put("original_claims", originalClaimsTag);
+		}
+		
 		return tag;
 	}
 
@@ -334,6 +374,27 @@ public class FTBChunksTeamData {
 				chunk.time = o.getLong("time");
 				chunk.forceLoaded = o.getLong("force_loaded");
 				manager.claimedChunks.put(chunk.pos, chunk);
+			}
+		}
+
+		CompoundTag originalClaimsTag = tag.getCompound("original_claims");
+		originalClaims.clear();
+		for (String idStr : originalClaimsTag.getAllKeys()) {
+			try {
+				UUID id = UUID.fromString(idStr);
+				CompoundTag playerTag = originalClaimsTag.getCompound(idStr);
+				for (String dimStr : playerTag.getAllKeys()) {
+					ResourceKey<Level> dimKey = ResourceKey.create(Registry.DIMENSION_REGISTRY, new ResourceLocation(dimStr));
+					Set<ChunkDimPos> cdpSet = new HashSet<>();
+					playerTag.getList(dimStr, NbtType.COMPOUND).forEach(el -> {
+						if (el instanceof CompoundTag) {
+							CompoundTag c = (CompoundTag) el;
+							cdpSet.add(new ChunkDimPos(dimKey, c.getInt("x"), c.getInt("z")));
+						}
+					});
+					originalClaims.put(id, cdpSet);
+				}
+			} catch (IllegalArgumentException ignored) {
 			}
 		}
 	}

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/FTBChunksTeamData.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/FTBChunksTeamData.java
@@ -39,6 +39,7 @@ public class FTBChunksTeamData {
 	public static final PrivacyProperty BLOCK_INTERACT_MODE = new PrivacyProperty(new ResourceLocation(FTBChunks.MOD_ID, "block_interact_mode"), PrivacyMode.ALLIES);
 	public static final PrivacyProperty MINIMAP_MODE = new PrivacyProperty(new ResourceLocation(FTBChunks.MOD_ID, "minimap_mode"), PrivacyMode.ALLIES);
 	public static final PrivacyProperty LOCATION_MODE = new PrivacyProperty(new ResourceLocation(FTBChunks.MOD_ID, "location_mode"), PrivacyMode.ALLIES);
+	public static final BooleanProperty ALLOW_EXPLOSIONS = new BooleanProperty(new ResourceLocation(FTBChunks.MOD_ID, "allow_explosions"), false);
 
 	public final ClaimedChunkManager manager;
 	private final Team team;
@@ -365,5 +366,9 @@ public class FTBChunksTeamData {
 	public static ServerPlayer playerOrNull(CommandSourceStack source) {
 		Entity entity = source.getEntity();
 		return entity instanceof ServerPlayer ? (ServerPlayer) entity : null;
+	}
+
+	public boolean allowExplosions() {
+		return team.getProperty(ALLOW_EXPLOSIONS);
 	}
 }

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/HeightUtils.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/HeightUtils.java
@@ -25,15 +25,17 @@ public class HeightUtils {
 		return state.isAir() || FTBChunks.PROXY.skipBlock(state);
 	}
 
-	public static BlockPos.MutableBlockPos getHeight(Level level, @Nullable ChunkAccess chunkAccess, BlockPos.MutableBlockPos pos, int[] currentWaterY) {
+	public static int getHeight(Level level, @Nullable ChunkAccess chunkAccess, BlockPos.MutableBlockPos pos) {
 		if (chunkAccess == null) {
-			return pos;
+			return UNKNOWN;
 		}
 
 		int bottomY = 0;
 		int topY = pos.getY();
 		boolean hasCeiling = level.dimensionType().hasCeiling();
+		int currentWaterY = UNKNOWN;
 
+		outer:
 		for (int by = topY; by >= bottomY; by--) {
 			pos.setY(by);
 			BlockState state = chunkAccess.getBlockState(pos);
@@ -43,25 +45,24 @@ public class HeightUtils {
 					pos.setY(by);
 					state = chunkAccess.getBlockState(pos);
 
-					if (state.isAir()) {
-						break;
+					if (skipBlock(state)) {
+						continue outer;
 					}
 				}
 			}
 
 			boolean water = isWater(state);
 
-			if (water && currentWaterY[0] == UNKNOWN) {
-				currentWaterY[0] = by;
+			if (water && currentWaterY == UNKNOWN) {
+				currentWaterY = by;
 			}
 
 			if (!water && !skipBlock(state)) {
-				pos.setY(by);
-				return pos;
+				return currentWaterY;
 			}
 		}
 
 		pos.setY(UNKNOWN);
-		return pos;
+		return UNKNOWN;
 	}
 }

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/net/SendManyChunksPacket.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/net/SendManyChunksPacket.java
@@ -17,11 +17,14 @@ import java.util.UUID;
  * @author LatvianModder
  */
 public class SendManyChunksPacket extends BaseS2CMessage {
-	public ResourceKey<Level> dimension;
-	public UUID teamId;
-	public List<SendChunkPacket.SingleChunk> chunks;
+	public final ResourceKey<Level> dimension;
+	public final UUID teamId;
+	public final List<SendChunkPacket.SingleChunk> chunks;
 
-	public SendManyChunksPacket() {
+	public SendManyChunksPacket(ResourceKey<Level> dimension, UUID teamId, List<SendChunkPacket.SingleChunk> chunks) {
+		this.dimension = dimension;
+		this.teamId = teamId;
+		this.chunks = chunks;
 	}
 
 	@Override

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/net/TeleportFromMapPacket.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/net/TeleportFromMapPacket.java
@@ -74,20 +74,19 @@ public class TeleportFromMapPacket extends BaseC2SMessage {
 					return;
 				}
 
-				BlockPos.MutableBlockPos blockPos = new BlockPos.MutableBlockPos(x, topY, z);
-				int[] water = new int[]{HeightUtils.UNKNOWN};
-				y1 = HeightUtils.getHeight(level, chunkAccess, blockPos, water).getY();
+				BlockPos.MutableBlockPos blockPos = new BlockPos.MutableBlockPos(x, topY + 2, z);
+				int water = HeightUtils.getHeight(level, chunkAccess, blockPos);
 
-				if (y1 == HeightUtils.UNKNOWN) {
-					y1 = 70;
+				if (blockPos.getY() == HeightUtils.UNKNOWN) {
+					blockPos.setY(70);
+				} else if (water != HeightUtils.UNKNOWN) {
+					blockPos.setY(Math.max(blockPos.getY(), water));
 				}
 
-				if (water[0] != HeightUtils.UNKNOWN) {
-					y1 = Math.max(y1, water[0]);
-				}
+				y1 = blockPos.getY() + 1;
 			}
 
-			p.teleportTo(level, x + 0.5D, y1 + 2.1D, z + 0.5D, p.yRot, p.xRot);
+			p.teleportTo(level, x + 0.5D, y1 + 0.1D, z + 0.5D, p.yRot, p.xRot);
 		}
 	}
 }

--- a/common/src/main/resources/assets/ftbchunks/lang/en_us.json
+++ b/common/src/main/resources/assets/ftbchunks/lang/en_us.json
@@ -69,6 +69,7 @@
 	"ftbchunks.gui.settings": "Settings",
 	"ftbchunks.gui.sync": "Share Map with Allies",
 	"ftbteamsconfig.ftbchunks.allow_fake_players": "Allow Fake Players",
+	"ftbteamsconfig.ftbchunks.allow_explosions": "Allow Explosions",
 	"ftbteamsconfig.ftbchunks.block_edit_mode": "Block Edit Mode",
 	"ftbteamsconfig.ftbchunks.block_interact_mode": "Block Interact Mode",
 	"ftbteamsconfig.ftbchunks.minimap_mode": "Minimap Mode",


### PR DESCRIPTION
The indicated area 'op' cannot be operated on. Can you configure OP as the maximum permission to operate the indicated player area.
This will make it easier for me to spot bad guys inside the server