### PR TITLE
[1.19] added unclaim control

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunks.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/FTBChunks.java
@@ -436,6 +436,7 @@ public class FTBChunks {
 	}
 
 	private void teamConfig(TeamCollectPropertiesEvent event) {
+		event.add(FTBChunksTeamData.OWNER_UNCLAIM);
 		event.add(FTBChunksTeamData.ALLOW_EXPLOSIONS);
 		event.add(FTBChunksTeamData.ALLOW_MOB_GRIEFING);
 		event.add(FTBChunksTeamData.ALLOW_ALL_FAKE_PLAYERS);

--- a/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunk.java
+++ b/common/src/main/java/dev/ftb/mods/ftbchunks/data/ClaimedChunk.java
@@ -113,6 +113,10 @@ public class ClaimedChunk implements ClaimResult {
 		return teamData.allowMobGriefing();
 	}
 
+	public boolean ownerUnclaim() {
+		return teamData.ownerUnclaim();
+	}
+
 	public void sendUpdateToAll() {
 		SendChunkPacket packet = new SendChunkPacket(pos.dimension, teamData.getTeamId(), new SendChunkPacket.SingleChunk(System.currentTimeMillis(), pos.x, pos.z, this));
 		ChunkSendingUtils.sendChunkToAll(teamData.manager.getMinecraftServer(), teamData, packet);

--- a/common/src/main/resources/assets/ftbchunks/lang/en_us.json
+++ b/common/src/main/resources/assets/ftbchunks/lang/en_us.json
@@ -122,6 +122,8 @@
 	"ftbteamsconfig.ftbchunks.location_mode.tooltip": "Controls who can see you on the map or minimap (outside the normal vanilla tracking range)",
 	"ftbteamsconfig.ftbchunks.claim_visibility": "Claim Visibility",
 	"ftbteamsconfig.ftbchunks.claim_visibility.tooltip": "Controls who can see your claims on the map or minimap",
+	"ftbteamsconfig.ftbchunks.owner_unclaim": "Owner Unclaim",
+	"ftbteamsconfig.ftbchunks.owner_unclaim.tooltip": "When true, only team owners can unclaim chunks",
 	"ftbchunks.fake_players": "Allow Fake Players",
 	"ftbchunks.fake_players.tooltip": "CHECK: check fake player access like any real player\nDENY: never allow fake players\nALLOW: always allow fake players",
 	"ftbchunks.max_claimed_chunks": "Max Claimed Chunks per Player",


### PR DESCRIPTION
New features which allows to configure who can unclaim chunks, only owner all everyone.

![image](https://github.com/FTBTeam/FTB-Chunks/assets/11539771/113e66e3-6fa4-49f3-b4cc-8f01584ab0d0)
