### PR TITLE
Create ftbchunks_block_colors.json

### DIFF
--- a/common/src/main/resources/assets/create/ftbchunks_block_colors.json
+++ b/common/src/main/resources/assets/create/ftbchunks_block_colors.json
@@ -1,0 +1,3 @@
+{
+	"framed_glass": "#CCE5E4"
+}


### PR DESCRIPTION
Added the framed_glass block from Create Mod to the map. Previously it shows up black.

Before:
![image](https://github.com/user-attachments/assets/214c8f3a-74df-4e40-a412-190fcec26fcb)


After:
![image](https://github.com/user-attachments/assets/7362d1be-4b75-4c4b-b128-38a36815ab40)
